### PR TITLE
MAINT, BUG: sync with upstream to unconditionaly disable use of aligned_alloc

### DIFF
--- a/pocketfft_hdronly.h
+++ b/pocketfft_hdronly.h
@@ -152,11 +152,11 @@ template<> struct VLEN<double> { static constexpr size_t val=2; };
 #endif
 #endif
 
-// the __MINGW32__ part in the conditional below works around the problem that
-// the standard C++ library on Windows does not provide aligned_alloc() even
-// though the MinGW compiler and MSVC may advertise C++17 compliance.
-// aligned_alloc is only supported from MacOS 10.15.
-#if (__cplusplus >= 201703L) && (!defined(__MINGW32__)) && (!defined(_MSC_VER)) && (__MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15)
+// std::aligned_alloc is a bit cursed ... it doesn't exist on MacOS < 10.15
+// and in musl, and other OSes seem to have even more peculiarities.
+// Let's unconditionally work around it for now.
+# if 0
+//#if (__cplusplus >= 201703L) && (!defined(__MINGW32__)) && (!defined(_MSC_VER)) && (__MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_15)
 inline void *aligned_alloc(size_t align, size_t size)
   {
   // aligned_alloc() requires that the requested size is a multiple of "align"


### PR DESCRIPTION
* sync with upstream to deal with https://github.com/scipy/scipy/issues/20300; as discussed there, our more conservative shim failed to fix the `conda-forge` issue for older MacOS, so let's turn this functionality off completely like NumPy did at https://github.com/numpy/numpy/pull/26123